### PR TITLE
Fix broken month view if last week of December is in next year

### DIFF
--- a/Classes/Domain/Model/Month.php
+++ b/Classes/Domain/Model/Month.php
@@ -78,7 +78,7 @@ class Month
         while ($currentDay <= $lastDay) {
             $this->weeks[] = new Week(
                 (int) $currentDay->format('W'),
-                (int) $currentDay->format('Y')
+                (int) $currentDay->format('o')
             );
 
             $currentDay = $currentDay->modify('+7 days');

--- a/Classes/Domain/Model/Week.php
+++ b/Classes/Domain/Model/Week.php
@@ -80,7 +80,7 @@ class Week
 
         return new self(
             (int) $newDay->format('W'),
-            (int) $newDay->format('Y')
+            (int) $newDay->format('o')
         );
     }
 
@@ -90,7 +90,7 @@ class Week
 
         return new self(
             (int) $newDay->format('W'),
-            (int) $newDay->format('Y')
+            (int) $newDay->format('o')
         );
     }
 

--- a/Documentation/Changelog/1.1.1.rst
+++ b/Documentation/Changelog/1.1.1.rst
@@ -14,7 +14,12 @@ Nothing
 Fixes
 -----
 
-Nothing
+* Fix broken month view if last week of December is in next year.
+
+  The cause was using the wrong character in formatting the year.
+  We now switch from `Y` to `o` which will work based on the week instead of date.
+  This is necessary as we provide this year to the week,
+  and therefore need the year of the week, not day.
 
 Tasks
 -----

--- a/Tests/Unit/Domain/Model/MonthTest.php
+++ b/Tests/Unit/Domain/Model/MonthTest.php
@@ -141,6 +141,28 @@ class MonthTest extends TestCase
     /**
      * @test
      */
+    public function returnsWeeksIfLastDecemberWeekIsInNextYear(): void
+    {
+        $subject = new Month(12, 2024);
+
+        $result = $subject->getWeeks();
+
+        self::assertCount(6, $result);
+
+        $week = array_pop($result);
+        $days = $week->getDays();
+        self::assertSame('2024-12-30', $days[0]->getDateTimeInstance()->format('Y-m-d'));
+        self::assertSame('2025-01-05', $days[6]->getDateTimeInstance()->format('Y-m-d'));
+
+        $week = array_pop($result);
+        $days = $week->getDays();
+        self::assertSame('2024-12-23', $days[0]->getDateTimeInstance()->format('Y-m-d'));
+        self::assertSame('2024-12-29', $days[6]->getDateTimeInstance()->format('Y-m-d'));
+    }
+
+    /**
+     * @test
+     */
     public function returnsAllDaysOfTheJuneMonth2021(): void
     {
         $subject = new Month(06, 2021);


### PR DESCRIPTION
The cause was using the wrong character in formatting the year. We now switch from `Y` to `o` which will work based on the week instead of date. This is necessary as we provide this year to the week, and therefore need the year of the week, not day.

Resolves: #11388